### PR TITLE
add kodi addon repository and inputsteam addon

### DIFF
--- a/kodi/Dockerfile
+++ b/kodi/Dockerfile
@@ -4,7 +4,7 @@ FROM $BASE_IMAGE
 #
 # install kodi
 RUN set -eux; apt-get update; \
-    apt-get install -y --no-install-recommends kodi; \
+    apt-get install -y --no-install-recommends kodi kodi-repository-kodi kodi-inputstream-adaptive; \
     #
     # clean up
     apt-get clean -y; \


### PR DESCRIPTION
this was needed for me to actually run any addons on kodi. even third party addons have dependencies from the official repository.